### PR TITLE
bugfix(loadAssets): 处理 xhr 加载失败的情况

### DIFF
--- a/src/mockWorker.js
+++ b/src/mockWorker.js
@@ -64,9 +64,20 @@ const actions = {
             const req = new XMLHttpRequest()
             req.open("GET", url, true);
             req.responseType = "arraybuffer"
-            req.onloadend = () => {
+            // load success
+            req.onload = () => {
                 actions.load_viaProto(req.response, cb, failure);
-            }
+            };
+            // load error
+            req.onerror = (err) => {
+                // Do not log to console or throw, if failure() exists
+                if (failure) {
+                    failure(err);
+                    return;
+                }
+                console.error(err);
+                throw err;
+            };
             req.send()
         }
     },
@@ -84,7 +95,11 @@ const actions = {
                 })
             })
         } catch (err) {
-            failure && failure(err);
+            // Do not log to console or throw, if failure() exists
+            if (failure) {
+                failure(err);
+                return;
+            }
             console.error(err);
             throw err;
         }


### PR DESCRIPTION
期望：
1. 加载失败时捕获到 ajax 错误
2. 当提供了 failure() 时，不抛到到 window.onerror 上

实际：
1. 加载失败时捕获到 null.length 错误
2. 当提供了 failure() 时，依然抛到到 window.onerror 上

本 PR 通过处理 xhr.onerror 解决了这个问题

https://gist.github.com/yiliashaw/328410404c35735f42f437dd5d9a8ca3