### PR TITLE
bugfix(loadAssets): Fix the problem that failing at requsting a base6…

### DIFF
--- a/src/mockWorker.js
+++ b/src/mockWorker.js
@@ -61,24 +61,31 @@ const actions = {
             }
         }
         else {
-            const req = new XMLHttpRequest()
-            req.open("GET", url, true);
-            req.responseType = "arraybuffer"
-            // load success
-            req.onload = () => {
-                actions.load_viaProto(req.response, cb, failure);
-            };
-            // load error
-            req.onerror = (err) => {
-                // Do not log to console or throw, if failure() exists
-                if (failure) {
-                    failure(err);
-                    return;
-                }
-                console.error(err);
-                throw err;
-            };
-            req.send()
+            const base64ExecResult = typeof url === "string" && /^data:(.{0,});base64,(.+)/.exec(url);
+            if (base64ExecResult) {
+                const arrayBufferSVGA = actions._base64ToArrayBuffer(base64ExecResult[2]);
+                actions.load_viaProto(arrayBufferSVGA, cb, failure);
+            }
+            else {
+                const req = new XMLHttpRequest()
+                req.open("GET", url, true);
+                req.responseType = "arraybuffer"
+                // load success
+                req.onload = () => {
+                    actions.load_viaProto(req.response, cb, failure);
+                };
+                // load error
+                req.onerror = (err) => {
+                    // Do not log to console or throw, if failure() exists
+                    if (failure) {
+                        failure(err);
+                        return;
+                    }
+                    console.error(err);
+                    throw err;
+                };
+                req.send()
+            }
         }
     },
 


### PR DESCRIPTION
Fix the problem that failing at requsting a base64 string as the src param of xhr.open in Internet Explorer.

处理IE无法使用base64字符串作为请求地址发起 xhr 请求的问题。
使用webpack打包后的base64时，若没有引入//s1.yy.com/ued_web_static/lib/jszip/3.1.4/??jszip.min.js,jszip-utils.min.js, 则在执行`parser.load(base64string)`后，会使用以下逻辑加载svga，
```
const req = new XMLHttpRequest()
req.open("GET", base64string, true);
```
这段逻辑在 chromium 内核的浏览器中可以正常运行，但在IE中会出现"拒绝访问"的问题，因此参考程序原有相关逻辑，作出这个修改，对base64字符串不在xhr中进行处理(考虑到不希望另外引入多一个js的情况下)。希望可以考虑下是否并入此修改。