### PR TITLE
fix: 补全setText方法的字体族默认值

### DIFF
--- a/src/Canvas/player.js
+++ b/src/Canvas/player.js
@@ -96,7 +96,7 @@ export class Player {
     setText(textORMap, forKey) {
         let text = typeof textORMap === "string" ? textORMap : textORMap.text;
         let size = (typeof textORMap === "object" ? textORMap.size : "14px") || "14px";
-        let family = (typeof textORMap === "object" ? textORMap.family : "") || "";
+        let family = (typeof textORMap === "object" ? textORMap.family : "Arial") || "Arial";
         let color = (typeof textORMap === "object" ? textORMap.color : "#000000") || "#000000";
         let offset = (typeof textORMap === "object" ? textORMap.offset : { x: 0.0, y: 0.0 }) || { x: 0.0, y: 0.0 };
         this._dynamicText[forKey] = {

--- a/src/CreateJS/player.js
+++ b/src/CreateJS/player.js
@@ -116,7 +116,7 @@ export class Player extends createjs.Container {
     setText(textORMap, forKey) {
         let text = typeof textORMap === "string" ? textORMap : textORMap.text;
         let size = (typeof textORMap === "object" ? textORMap.size : "14px") || "14px";
-        let family = (typeof textORMap === "object" ? textORMap.family : "") || "";
+        let family = (typeof textORMap === "object" ? textORMap.family : "Arial") || "Arial";
         let color = (typeof textORMap === "object" ? textORMap.color : "#000000") || "#000000";
         let offset = (typeof textORMap === "object" ? textORMap.offset : { x: 0.0, y: 0.0 }) || { x: 0.0, y: 0.0 };
         let textLayer = new createjs.Text(text, `${size} family`, color);

--- a/src/LayaBox/player.js
+++ b/src/LayaBox/player.js
@@ -132,7 +132,7 @@ export class Player extends Laya.Sprite {
     setText(textORMap, forKey) {
         let text = typeof textORMap === "string" ? textORMap : textORMap.text;
         let size = (typeof textORMap === "object" ? textORMap.size : "14px") || "14px";
-        let family = (typeof textORMap === "object" ? textORMap.family : "") || "";
+        let family = (typeof textORMap === "object" ? textORMap.family : "Arial") || "Arial";
         let color = (typeof textORMap === "object" ? textORMap.color : "#000000") || "#000000";
         let offset = (typeof textORMap === "object" ? textORMap.offset : { x: 0.0, y: 0.0 }) || { x: 0.0, y: 0.0 };
         let textLayer = new Laya.Text();

--- a/tests/canvas.html
+++ b/tests/canvas.html
@@ -10,7 +10,7 @@
         <script src="../build/svga.ie.min.js"></script>
     <![endif]-->
     <!--[if gte IE 10]><!-->
-    <script src="http://assets.dwstatic.com/common/lib/??jszip/3.1.3/jszip.min.js,jszip/3.1.3/jszip-utils.min.js"
+    <script src="http://s1.yy.com/ued_web_static/lib/jszip/3.1.4/??jszip.min.js,jszip-utils.min.js"
         charset="utf-8"></script>
     <script src="../build/svga.min.js"></script>
     <!--<![endif]-->


### PR DESCRIPTION
修复setText方法不传family参数时会失效的问题